### PR TITLE
Add timestamp to default output filename to prevent overwriting

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 import yaml
 import pandas as pd
+from datetime import datetime
 
 # Add src directory to path
 sys.path.append(str(Path(__file__).parent / 'src'))
@@ -53,7 +54,7 @@ Examples:
     parser.add_argument(
         '--output', '-o',
         type=str,
-        required=True,
+        default="output/fmea_output.xlsx",
         help='Output file path for generated FMEA'
     )
     
@@ -135,16 +136,28 @@ Examples:
     
     print(f"\n✅ FMEA generated successfully with {len(fmea_df)} entries")
     
-    # Export
-    output_path = Path(args.output)
-    
-    if args.format == 'json':
-        from utils import export_to_json
-        export_to_json(fmea_df, str(output_path))
-    else:
-        generator.export_fmea(fmea_df, str(output_path), format=args.format)
-    
-    print(f"📁 FMEA exported to: {output_path}")
+# Export
+default_output = "output/fmea_output.xlsx"
+output_str = args.output
+
+# If user did NOT override default, append timestamp
+if output_str == default_output:
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    base_path = Path(default_output)
+    output_str = str(
+        base_path.parent / f"{base_path.stem}_{timestamp}{base_path.suffix}"
+    )
+
+output_path = Path(output_str)
+output_path.parent.mkdir(parents=True, exist_ok=True)
+
+if args.format == 'json':
+    from utils import export_to_json
+    export_to_json(fmea_df, str(output_path))
+else:
+    generator.export_fmea(fmea_df, str(output_path), format=args.format)
+
+print(f"📁 FMEA exported to: {output_path}")
     
     # Print summary if requested
     if args.summary:


### PR DESCRIPTION
- Made --output optional with default value
- Append timestamp when default output is used
- Preserve exact filename when user provides custom --output
- Ensure output directory exists

## Team Number : 106

## Description
This PR updates the CLI output behavior to prevent accidental overwriting of files when the --output argument is not explicitly provided.

If the user does not specify --output, the default filename (output/fmea_output.xlsx) now automatically appends a timestamp using:

datetime.now().strftime("%Y-%m-%d_%H-%M-%S")

If the user provides a custom filename via --output, that filename is preserved exactly as given.

The final output path is printed to the console after export.


## Related Issue
<!-- (https://github.com/gdg-charusat/FMEA_SupplyChain/issues/3) -->
Closes #3

## Type of Change
<!-- Please check the relevant option(s) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Style/UI improvement

## Changes Made
<!-- Made --output optional with default value output/fmea_output.xlsx

Added timestamp to default output filename to prevent overwriting

Preserved exact filename when custom --output is provided

Ensured output directory is created if it does not exist

Printed final output path to console after export

Imported datetime module in cli.py -->
- 
- 
- 

## Screenshots (if applicable)
<!-- Add before/after screenshots for UI changes -->

**Before:**


**After:**


## Testing
<!-- Describe the tests you ran to verify your changes -->
- [ ] Tested on Desktop (Chrome/Firefox/Safari)
- [ ] Tested on Mobile (iOS/Android)
- [ ] Tested responsive design (different screen sizes)
- [ ] No console errors or warnings
- [ ] Code builds successfully (`npm run build`)

## Checklist
<!-- Mark completed items with [x] -->
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have tested my changes thoroughly
- [ ] All TypeScript types are properly defined
- [ ] Tailwind CSS classes are used appropriately (no inline styles)
- [ ] Component is responsive across different screen sizes
- [ ] I have read and followed the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

## Additional Notes
<!-- Any additional information, concerns, or context -->
